### PR TITLE
Fix help text for --retries to match actual default value

### DIFF
--- a/src/open_r1/generate.py
+++ b/src/open_r1/generate.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
         "--retries",
         type=int,
         default=0,
-        help="Number of retries for failed requests (default: 3)",
+        help="Number of retries for failed requests (default: 0)",
     )
     parser.add_argument(
         "--hf-output-dataset",


### PR DESCRIPTION
The argparse help text for --retries stated the default was 3, but the actual default set in code is 0. This update corrects the help text to prevent confusion.