### PR TITLE
Update: Fix eval crash by disabling vLLM when using DeepSpeed

### DIFF
--- a/recipes/qwen/Qwen2.5-1.5B-Instruct/grpo/confg_full.yaml
+++ b/recipes/qwen/Qwen2.5-1.5B-Instruct/grpo/confg_full.yaml
@@ -12,7 +12,7 @@ num_processes: 7
 
 # GRPO trainer config
 bf16: true
-use_vllm: true
+use_vllm: false
 vllm_device: auto
 vllm_gpu_memory_utilization: 0.7
 do_eval: true


### PR DESCRIPTION
PR Description:

What’s broken:
In #145 evaluation crashes with AttributeError: model has no 'optimizer' because DeepSpeed Zero-3 hides the optimizer (it’s managed separately), and vLLM’s setup clashes with this.

The fix:
Disable vLLM in config_full.yaml. This stops the conflict and DeepSpeed now handles everything correctly.